### PR TITLE
[RFR] Adding some functionality from Meta-git into Kepler

### DIFF
--- a/commands/docker/command.go
+++ b/commands/docker/command.go
@@ -117,8 +117,5 @@ func (conf *Config) validate() error {
 	if conf.Application == "" {
 		return fmt.Errorf("Application does not have a valid value")
 	}
-	if conf.Type == "" {
-		return fmt.Errorf("Type does not have a valid value")
-	}
 	return nil
 }

--- a/commands/docker/command.go
+++ b/commands/docker/command.go
@@ -53,11 +53,11 @@ type Config struct {
 // and prepares the Dockerfile template defined in `ProjectDir/.kepler/Dockerfile`
 // On success, it will return a struct with all the required information
 // Otherwise, review the returned error message
-func CreateConfig(ProjectDir string) (*Config, error) {
-	if ProjectDir == "." {
-		ProjectDir = ""
+func CreateConfig(projectDir string) (*Config, error) {
+	if projectDir == "." {
+		projectDir = ""
 	}
-	conf := path.Join(ProjectDir, ".kepler/config.yaml")
+	conf := path.Join(projectDir, ".kepler/config.yaml")
 	if _, err := os.Stat(conf); os.IsNotExist(err) {
 		return nil, fmt.Errorf("Unable to find %s", conf)
 	}
@@ -66,7 +66,7 @@ func CreateConfig(ProjectDir string) (*Config, error) {
 		return nil, err
 	}
 	config := Config{
-		Application: path.Base(ProjectDir),
+		Application: path.Base(projectDir),
 	}
 	if err = yaml.Unmarshal(b, &config); err != nil {
 		return nil, err
@@ -76,7 +76,7 @@ func CreateConfig(ProjectDir string) (*Config, error) {
 	if config.Type == "" {
 		config.Type = noResolution
 	}
-	template := path.Join(ProjectDir, ".kepler/Dockerfile.tmpl")
+	template := path.Join(projectDir, ".kepler/Dockerfile.tmpl")
 	if _, err = os.Stat(template); os.IsNotExist(err) {
 		return nil, fmt.Errorf("Expected file %s missing", template)
 	}

--- a/commands/docker/command.go
+++ b/commands/docker/command.go
@@ -49,6 +49,8 @@ type Config struct {
 // On success, it will return a struct with all the required information
 // Otherwise, review the returned error message
 func CreateConfig(projectDir string) (*Config, error) {
+	// If we have been told to use the local directory,
+	// Set it to blank so that we don't mess up references
 	if projectDir == "." {
 		projectDir = ""
 	}

--- a/commands/docker/command.go
+++ b/commands/docker/command.go
@@ -10,6 +10,7 @@ import (
 	"text/template"
 
 	"github.com/AlexsJones/kepler/commands/node"
+	sh "github.com/AlexsJones/kepler/commands/shell"
 	yaml "gopkg.in/yaml.v2"
 )
 
@@ -32,6 +33,7 @@ func init() {
 // in order to build the given application as a
 // docker image
 type Config struct {
+	// Application is always assumed to be the base name of the current directory
 	Application string
 	// Type allows for correct resolution of required resources
 	Type      string   `yaml:"Type"`
@@ -45,6 +47,9 @@ type Config struct {
 // On success, it will return a struct with all the required information
 // Otherwise, review the returned error message
 func CreateConfig(ProjectDir string) (*Config, error) {
+	if ProjectDir == "." {
+		ProjectDir = ""
+	}
 	conf := path.Join(ProjectDir, ".kepler/config.yaml")
 	if _, err := os.Stat(conf); os.IsNotExist(err) {
 		return nil, fmt.Errorf("Unable to find %s", conf)
@@ -117,6 +122,10 @@ func (conf *Config) CreateMetaFile() ([]byte, error) {
 		return nil, err
 	}
 	return conf.prepareTemplate()
+}
+
+func BuildImage(buildArgs ...string) error {
+	return sh.ShellCommand(fmt.Sprintf("docker build %s .", strings.Join(buildArgs, " ")), ".", false)
 }
 
 func (conf *Config) validate() error {

--- a/commands/docker/command.go
+++ b/commands/docker/command.go
@@ -81,9 +81,6 @@ func (conf *Config) prepareTemplate() ([]byte, error) {
 		} else {
 			conf.Resources = deps
 		}
-	case "noresolution":
-	default:
-		conf.Resources = []string{}
 	}
 	t := template.Must(template.New("Dockerfile").Parse(string(conf.Template)))
 	dockerfile := &bytes.Buffer{}

--- a/commands/docker/command.go
+++ b/commands/docker/command.go
@@ -44,3 +44,23 @@ func CreateDockerfile(application string) ([]byte, error) {
 	t.Execute(dockerfile, resources)
 	return dockerfile.Bytes(), nil
 }
+
+func BuildImage(application string) (err error) {
+	_, err = CreateDockerfile(application)
+	if err != nil {
+		return err
+	}
+	// cli, err := client.NewEnvClient()
+	// if err != nil {
+	// 	return err
+	// }
+	// _, err := cli.ImageBuild(context.Background(), dockerfile, types.ImageBuildOptions{
+	// 	Tags:       []string{application},
+	// 	NoCache:    true,
+	// 	PullParent: true,
+	// })
+	// if err != nil {
+	// 	return err
+	// }
+	return nil
+}

--- a/commands/docker/command.go
+++ b/commands/docker/command.go
@@ -6,57 +6,122 @@ import (
 	"io/ioutil"
 	"os"
 	"path"
+	"strings"
 	"text/template"
 
 	"github.com/AlexsJones/kepler/commands/node"
-	sh "github.com/AlexsJones/kepler/commands/shell"
+	yaml "gopkg.in/yaml.v2"
 )
 
-type Resources struct {
+type ResolutionType int
+
+const (
+	NoResolution = iota
+	Node
+)
+
+// resolver is declared to use in printing out
+var resolver = []string{
+	"NoResolution",
+	"Node",
+}
+
+// String returns a human readable version of the ResolutionType
+func (res ResolutionType) String() string {
+	if int(res) > len(resolver) {
+		return "Undefined ResolutionType"
+	}
+	return resolver[res]
+}
+
+// Config contains all the required information
+// in order to build the given application as a
+// docker image
+type Config struct {
 	Application string
-	Resources   []string
+	// Type allows for correct resolution of required resources
+	Type      string   `yaml:"Type"`
+	BuildArgs []string `yaml:"BuildArgs"`
+	Resources []string
+	Template  []byte
 }
 
-var (
-	TemplateDirectory string
-	BuildArgs         string
-)
-
-func init() {
-	TemplateDirectory = "templates"
-}
-
-func CreateDockerfile(application string) ([]byte, error) {
-	file := path.Join(TemplateDirectory, fmt.Sprintf("%s.Dockerfile", application))
-	if _, err := os.Stat(file); os.IsNotExist(err) {
-		return nil, fmt.Errorf("Can not load %s", file)
+func CreateConfig(ProjectDir string) (*Config, error) {
+	conf := path.Join(ProjectDir, ".kepler/config.yaml")
+	if _, err := os.Stat(conf); os.IsNotExist(err) {
+		return nil, fmt.Errorf("Unable to find %s", conf)
 	}
-	resources := &Resources{
-		Application: application,
-	}
-	if deps, err := node.ResolveLocalDependancies(application); err != nil {
-		return nil, err
-	} else {
-		resources.Resources = deps
-	}
-	b, err := ioutil.ReadFile(file)
+	b, err := ioutil.ReadFile(conf)
 	if err != nil {
 		return nil, err
 	}
-	t := template.Must(template.New("Dockerfile").Parse(string(b)))
+	config := Config{
+		Application: ProjectDir,
+	}
+	if err = yaml.Unmarshal(b, &config); err != nil {
+		return nil, err
+	}
+	template := path.Join(ProjectDir, ".kepler/Dockerfile")
+	if _, err = os.Stat(template); os.IsNotExist(err) {
+		return nil, fmt.Errorf("Expected file %s missing", template)
+	}
+	b, err = ioutil.ReadFile(template)
+	if err != nil {
+		return nil, err
+	}
+	config.Template = b
+	return &config, nil
+}
+
+func (conf *Config) prepareTemplate() ([]byte, error) {
+	switch strings.ToLower(conf.Type) {
+	case "node":
+		if deps, err := node.ResolveLocalDependancies(conf.Application); err != nil {
+			return nil, err
+		} else {
+			conf.Resources = deps
+		}
+	case "noresolution":
+	default:
+		conf.Resources = []string{}
+	}
+	t := template.Must(template.New("Dockerfile").Parse(string(conf.Template)))
 	dockerfile := &bytes.Buffer{}
-	t.Execute(dockerfile, resources)
-	return dockerfile.Bytes(), nil
+	err := t.Execute(dockerfile, conf)
+	return dockerfile.Bytes(), err
 }
 
-func BuildImage(application string) (err error) {
-	b, err := CreateDockerfile(application)
-	if err != nil {
-		return err
+// CreateStandaloneFile strips all the templating from the original template
+// without doing any resource resolution and returns a byte stream that is used as the dockerfile
+func (conf *Config) CreateStandaloneFile() ([]byte, error) {
+	// Have to modify the application name to be dot to
+	// ensure it copies the files in the current directory
+	if err := conf.validate(); err != nil {
+		return nil, err
 	}
-	if err = ioutil.WriteFile("Dockerfile", b, 0644); err != nil {
-		return err
+	name := conf.Application
+	conf.Application = "."
+	conf.Type = "noresolution"
+	b, err := conf.prepareTemplate()
+	conf.Application = name
+	return b, err
+}
+
+// CreateMetaFile will create a dockerfile based off the config.Type
+// and the resources it requires
+func (conf *Config) CreateMetaFile() ([]byte, error) {
+	if err := conf.validate(); err != nil {
+		return nil, err
 	}
-	sh.ShellCommand(fmt.Sprintf("docker build -t %s %s .", application, BuildArgs), "", true)
+	return conf.prepareTemplate()
+}
+
+func (conf *Config) validate() error {
+	if conf.Application == "" {
+		return fmt.Errorf("Application does not have a valid value")
+	}
+	if conf.Type == "" {
+		return fmt.Errorf("Type does not have a valid value")
+	}
 	return nil
 }

--- a/commands/docker/command.go
+++ b/commands/docker/command.go
@@ -1,0 +1,46 @@
+package docker
+
+import (
+	"bytes"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path"
+	"text/template"
+
+	"github.com/AlexsJones/kepler/commands/node"
+)
+
+type Resources struct {
+	Application string
+	Resources   []string
+}
+
+var TemplateDirectory string
+
+func init() {
+	TemplateDirectory = "templates"
+}
+
+func CreateDockerfile(application string) ([]byte, error) {
+	file := path.Join(TemplateDirectory, fmt.Sprintf("%s.Dockerfile", application))
+	if _, err := os.Stat(file); os.IsNotExist(err) {
+		return nil, fmt.Errorf("Can not load %s", file)
+	}
+	resources := &Resources{
+		Application: application,
+	}
+	if deps, err := node.ResolveLocalDependancies(application); err != nil {
+		return nil, err
+	} else {
+		resources.Resources = deps
+	}
+	b, err := ioutil.ReadFile(file)
+	if err != nil {
+		return nil, err
+	}
+	t := template.Must(template.New("Dockerfile").Parse(string(b)))
+	dockerfile := &bytes.Buffer{}
+	t.Execute(dockerfile, resources)
+	return dockerfile.Bytes(), nil
+}

--- a/commands/docker/command.go
+++ b/commands/docker/command.go
@@ -18,8 +18,6 @@ import (
 // the required external resources that could be found inside the meta repo
 var Resolvers map[string]func(string) ([]string, error)
 
-const noResolution = "none"
-
 func init() {
 	Resolvers = map[string]func(string) ([]string, error){
 		// If we are going to build a node project from the meta
@@ -29,9 +27,6 @@ func init() {
 		"node": func(project string) ([]string, error) {
 			node.LinkLocalDeps()
 			return node.Resolve(project)
-		},
-		noResolution: func(empty string) ([]string, error) {
-			return []string{}, nil
 		},
 	}
 }
@@ -73,9 +68,6 @@ func CreateConfig(projectDir string) (*Config, error) {
 	}
 	// Enforce that resources are not resolved for this if
 	// config type isn't defined
-	if config.Type == "" {
-		config.Type = noResolution
-	}
 	template := path.Join(projectDir, ".kepler/Dockerfile.tmpl")
 	if _, err = os.Stat(template); os.IsNotExist(err) {
 		return nil, fmt.Errorf("Expected file %s missing", template)
@@ -90,15 +82,13 @@ func CreateConfig(projectDir string) (*Config, error) {
 
 func (conf *Config) prepareTemplate() ([]byte, error) {
 	resolverType := strings.ToLower(conf.Type)
-	if _, exist := Resolvers[resolverType]; !exist {
-		return nil, fmt.Errorf("Undefined project type")
-	}
-	if resources, err := Resolvers[resolverType](conf.Application); err != nil {
-		return nil, err
-	} else {
-		if resolverType != noResolution {
-			conf.Resources = append(conf.Resources, resources...)
+	resolverFunc, exist := Resolvers[resolverType]
+	if exist {
+		addtional, err := resolverFunc(conf.Application)
+		if err != nil {
+			return nil, err
 		}
+		conf.Resources = append(conf.Resources, addtional...)
 	}
 	t := template.Must(template.New("Dockerfile").Parse(string(conf.Template)))
 	dockerfile := &bytes.Buffer{}
@@ -116,7 +106,7 @@ func (conf *Config) CreateStandaloneFile() ([]byte, error) {
 	}
 	name := conf.Application
 	conf.Application = "."
-	conf.Type = noResolution
+	conf.Type = ""
 	b, err := conf.prepareTemplate()
 	conf.Application = name
 	return b, err
@@ -140,9 +130,6 @@ func BuildImage(buildArgs ...string) error {
 func (conf *Config) validate() error {
 	if conf.Application == "" {
 		return fmt.Errorf("Application does not have a valid value")
-	}
-	if conf.Type == "" {
-		conf.Type = noResolution
 	}
 	return nil
 }

--- a/commands/docker/command.go
+++ b/commands/docker/command.go
@@ -76,7 +76,7 @@ func CreateConfig(ProjectDir string) (*Config, error) {
 	if config.Type == "" {
 		config.Type = noResolution
 	}
-	template := path.Join(ProjectDir, ".kepler/Dockerfile")
+	template := path.Join(ProjectDir, ".kepler/Dockerfile.tmpl")
 	if _, err = os.Stat(template); os.IsNotExist(err) {
 		return nil, fmt.Errorf("Expected file %s missing", template)
 	}
@@ -132,6 +132,8 @@ func (conf *Config) CreateMetaFile() ([]byte, error) {
 }
 
 func BuildImage(buildArgs ...string) error {
+	// Once someone creates an actual working golang api to interact with Docker
+	// this is the best I can do.
 	return sh.ShellCommand(fmt.Sprintf("docker build %s .", strings.Join(buildArgs, " ")), ".", false)
 }
 

--- a/commands/docker/command.go
+++ b/commands/docker/command.go
@@ -22,7 +22,14 @@ const noResolution = "none"
 
 func init() {
 	Resolvers = map[string]func(string) ([]string, error){
-		"node": node.Resolve,
+		// If we are going to build a node project from the meta
+		// repo, we must enforce that we link all resolved projects.
+		// Doing it inline as it shouldn't be called by any other
+		// part of the application bare this part.
+		"node": func(project string) ([]string, error) {
+			node.LinkLocalDeps()
+			return node.Resolve(project)
+		},
 		noResolution: func(empty string) ([]string, error) {
 			return []string{}, nil
 		},

--- a/commands/docker/docker.go
+++ b/commands/docker/docker.go
@@ -38,6 +38,7 @@ func AddCommands(cli *cli.Cli) {
 							color.Red("%v", err)
 							return
 						}
+						// Make sure we remove our templated Dockerfile once we are done
 						defer os.Remove("Dockerfile")
 					}
 					BuildImage(args...)

--- a/commands/docker/docker.go
+++ b/commands/docker/docker.go
@@ -1,0 +1,40 @@
+package docker
+
+import (
+	"io/ioutil"
+
+	"github.com/AlexsJones/cli/cli"
+	"github.com/AlexsJones/cli/command"
+	"github.com/fatih/color"
+)
+
+func AddCommands(cli *cli.Cli) {
+	cli.AddCommand(command.Command{
+		Name: "docker",
+		Help: "docker command palette",
+		Func: func(args []string) {},
+		SubCommands: []command.Command{
+			command.Command{
+				Name: "create",
+				Help: "Creates a dockerfile from a template",
+				Func: func(args []string) {
+					if len(args) == 0 {
+						color.Red("Requires an argument to know what to build")
+						return
+					}
+					project := args[0]
+					dockerfile, err := CreateDockerfile(project)
+					if err != nil {
+						color.Red("An issue occured: %s", err.Error())
+						return
+					}
+					if err = ioutil.WriteFile("Dockerfile", dockerfile, 0644); err != nil {
+						color.Red("%s", err.Error())
+					} else {
+						color.Green("Successfully created Dockerfile for %s", project)
+					}
+				},
+			},
+		},
+	})
+}

--- a/commands/docker/docker.go
+++ b/commands/docker/docker.go
@@ -1,11 +1,8 @@
 package docker
 
 import (
-	"strings"
-
 	"github.com/AlexsJones/cli/cli"
 	"github.com/AlexsJones/cli/command"
-	"github.com/AlexsJones/kepler/commands/node"
 	"github.com/fatih/color"
 )
 
@@ -13,35 +10,8 @@ func AddCommands(cli *cli.Cli) {
 	cli.AddCommand(command.Command{
 		Name: "docker",
 		Help: "docker command palette",
-		Func: func(args []string) {},
-		SubCommands: []command.Command{
-			command.Command{
-				Name: "build",
-				Help: "Builds a docker image from a template",
-				Func: func(args []string) {
-					if len(args) == 0 {
-						color.Blue("build requires arguments")
-						return
-					}
-					node.LinkLocalDeps()
-					defer node.RestoreBackups()
-					for _, project := range args {
-						color.Green("Starting to build %s", project)
-						if err := BuildImage(project); err != nil {
-							color.Red("Problem occured: %s", err.Error())
-							return
-						}
-					}
-				},
-			},
-			command.Command{
-				Name: "build-args",
-				Help: "Sets the required build args for kepler",
-				Func: func(args []string) {
-					BuildArgs = strings.Join(args, " ")
-					color.Green("Build args is now set to: %s", BuildArgs)
-				},
-			},
+		Func: func(args []string) {
+			color.Magenta("WIP")
 		},
 	})
 }

--- a/commands/docker/docker.go
+++ b/commands/docker/docker.go
@@ -41,7 +41,9 @@ func AddCommands(cli *cli.Cli) {
 						// Make sure we remove our templated Dockerfile once we are done
 						defer os.Remove("Dockerfile")
 					}
-					BuildImage(args...)
+					if err := BuildImage(args...); err != nil {
+						color.Green("Success")
+					}
 				},
 			},
 		},

--- a/commands/docker/docker.go
+++ b/commands/docker/docker.go
@@ -14,7 +14,7 @@ func AddCommands(cli *cli.Cli) {
 		Name: "docker",
 		Help: "docker command palette",
 		Func: func(args []string) {
-			color.Magenta("WIP")
+			color.Magenta("Please see the help for usage")
 		},
 		SubCommands: []command.Command{
 			command.Command{

--- a/commands/docker/docker.go
+++ b/commands/docker/docker.go
@@ -1,6 +1,9 @@
 package docker
 
 import (
+	"io/ioutil"
+	"os"
+
 	"github.com/AlexsJones/cli/cli"
 	"github.com/AlexsJones/cli/command"
 	"github.com/fatih/color"
@@ -12,6 +15,34 @@ func AddCommands(cli *cli.Cli) {
 		Help: "docker command palette",
 		Func: func(args []string) {
 			color.Magenta("WIP")
+		},
+		SubCommands: []command.Command{
+			command.Command{
+				Name: "build",
+				Help: "Builds a project in standalone from the defined Dockerfile",
+				Func: func(args []string) {
+					if _, err := os.Stat("Dockerfile"); os.IsNotExist(err) {
+						color.Blue("No Dockerfile found locally")
+						color.Blue("Attempting to build a dockerfile from a template")
+						config, err := CreateConfig(".")
+						if err != nil {
+							color.Red("%v", err)
+							return
+						}
+						dockerfile, err := config.CreateStandaloneFile()
+						if err != nil {
+							color.Red("%v", err)
+							return
+						}
+						if err = ioutil.WriteFile("Dockerfile", dockerfile, 0644); err != nil {
+							color.Red("%v", err)
+							return
+						}
+						defer os.Remove("Dockerfile")
+					}
+					BuildImage(args...)
+				},
+			},
 		},
 	})
 }

--- a/commands/docker/docker_test.go
+++ b/commands/docker/docker_test.go
@@ -100,4 +100,8 @@ func TestUndefinedValues(t *testing.T) {
 	if _, err := config.CreateStandaloneFile(); err == nil {
 		t.Error("Failed to report on missing attributes")
 	}
+	config.Application = "ValidString"
+	if _, err := config.CreateStandaloneFile(); err != nil {
+		t.Errorf("Should be an empty dockerfile")
+	}
 }

--- a/commands/docker/docker_test.go
+++ b/commands/docker/docker_test.go
@@ -21,13 +21,12 @@ COPY . /src
 `
 	config := &docker.Config{
 		Application: "Test Application",
-		Type:        "NoResolution",
 		Resources:   []string{},
 		Template:    []byte(template),
 	}
 	dockerfile, err := config.CreateStandaloneFile()
 	if err != nil {
-		t.Error("The template is rendered incorrectly: %v", err)
+		t.Error("The template is rendered incorrectly:", err)
 	}
 	if string(dockerfile) != ExpectedTemplate {
 		t.Log("Expected template:\n", ExpectedTemplate)
@@ -44,7 +43,6 @@ Plz break
 	`
 	config := &docker.Config{
 		Application: "Test Application",
-		Type:        "NoResolution",
 		Resources:   []string{},
 		Template:    []byte(template),
 	}
@@ -75,7 +73,6 @@ RUN echo 3
 `
 	config := &docker.Config{
 		Application: "Test Application",
-		Type:        "NoResolution",
 		Resources:   []string{"1", "2", "3"},
 		Template:    []byte(template),
 	}
@@ -99,6 +96,9 @@ func TestUndefinedValues(t *testing.T) {
 	config := &docker.Config{}
 	if _, err := config.CreateStandaloneFile(); err == nil {
 		t.Error("Failed to report on missing attributes")
+	}
+	if _, err := config.CreateMetaFile(); err == nil {
+		t.Error("Failed to report on missing Application name")
 	}
 	config.Application = "ValidString"
 	if _, err := config.CreateStandaloneFile(); err != nil {

--- a/commands/docker/docker_test.go
+++ b/commands/docker/docker_test.go
@@ -1,0 +1,103 @@
+package docker_test
+
+import (
+	"testing"
+
+	"github.com/AlexsJones/kepler/commands/docker"
+)
+
+func TestStandaloneCreation(t *testing.T) {
+	template := `
+FROM scratch
+
+COPY {{.Application}} /src
+{{range .Resources}}
+SHOULD NOT EXISTS {{.}}
+{{end}}`
+	ExpectedTemplate := `
+FROM scratch
+
+COPY . /src
+`
+	config := &docker.Config{
+		Application: "Test Application",
+		Type:        "NoResolution",
+		Resources:   []string{},
+		Template:    []byte(template),
+	}
+	dockerfile, err := config.CreateStandaloneFile()
+	if err != nil {
+		t.Error("The template is rendered incorrectly: %v", err)
+	}
+	if string(dockerfile) != ExpectedTemplate {
+		t.Log("Expected template:\n", ExpectedTemplate)
+		t.Log("Given Template:\n", string(dockerfile))
+		t.Error("Template was wrong!")
+	}
+}
+
+func TestBadTemplate(t *testing.T) {
+	template := `
+FROM {{.Undefined}}
+
+Plz break
+	`
+	config := &docker.Config{
+		Application: "Test Application",
+		Type:        "NoResolution",
+		Resources:   []string{},
+		Template:    []byte(template),
+	}
+
+	if _, err := config.CreateStandaloneFile(); err == nil {
+		t.Error("Undefined template should report an error")
+	}
+}
+
+func TestTemplateRequiringResources(t *testing.T) {
+	template := `
+FROM scratch:latest
+
+COPY {{.Application}} /src/{{.Application}}
+{{range .Resources}}
+RUN echo {{.}}
+{{end}}`
+	expectedResult := `
+FROM scratch:latest
+
+COPY Test Application /src/Test Application
+
+RUN echo 1
+
+RUN echo 2
+
+RUN echo 3
+`
+	config := &docker.Config{
+		Application: "Test Application",
+		Type:        "NoResolution",
+		Resources:   []string{"1", "2", "3"},
+		Template:    []byte(template),
+	}
+	result, err := config.CreateMetaFile()
+	if err != nil {
+		t.Error("Template file should not fail")
+	}
+	if string(result) != expectedResult {
+		t.Log("Expected template:\n", expectedResult)
+		t.Log("Given Template:\n", string(result))
+		t.Error("Failed to create expected file")
+	}
+}
+
+func TestUndefinedValues(t *testing.T) {
+	defer func() {
+		if r := recover(); r != nil {
+			t.Error("Code had to recover instead of fail gracefully")
+		}
+	}()
+	config := &docker.Config{}
+	if _, err := config.CreateStandaloneFile(); err == nil {
+		t.Error("Failed to report on missing attributes")
+	}
+}

--- a/commands/kubebuilder/commands.go
+++ b/commands/kubebuilder/commands.go
@@ -13,6 +13,7 @@ import (
 	event "github.com/AlexsJones/cloud-transponder/events"
 	"github.com/AlexsJones/cloud-transponder/events/pubsub"
 	"github.com/AlexsJones/kepler/commands/docker"
+	"github.com/AlexsJones/kepler/commands/node"
 	"github.com/AlexsJones/kepler/commands/storage"
 	"github.com/AlexsJones/kubebuilder/src/data"
 	login "github.com/GoogleCloudPlatform/docker-credential-gcr/auth"
@@ -117,6 +118,15 @@ func BuildDockerImage(project string) error {
 	if err != nil {
 		return err
 	}
+
+	// When resolve different config Types, we may also be rewriting
+	// content on disc, so this should ensure that content is always
+	// always as the user left it.
+	switch config.Type {
+	case "node":
+		defer node.RestoreBackups()
+	}
+
 	dockerfile, err := config.CreateMetaFile()
 	if err != nil {
 		return err

--- a/commands/kubebuilder/commands.go
+++ b/commands/kubebuilder/commands.go
@@ -47,14 +47,14 @@ func loadKubebuilderFile() (*data.BuildDefinition, error) {
 	//Load yaml
 	raw, err := ioutil.ReadFile(".kubebuilder/build.yaml")
 	if err != nil {
-		log.Fatal(err)
+		return nil, err
 	}
 	//Hand cranking a build definition for the test
 	builddef := data.BuildDefinition{}
 
 	err = yaml.Unmarshal(raw, &builddef)
 	if err != nil {
-		log.Fatalf("error: %v", err)
+		return nil, err
 	}
 	log.Printf("%v\n", builddef)
 

--- a/commands/kubebuilder/commands.go
+++ b/commands/kubebuilder/commands.go
@@ -107,8 +107,9 @@ func publishKubebuilderfile(build *data.BuildDefinition) error {
 
 func authenticateDocker() error {
 	for _, registry := range []string{"gcr.io", "us.gcr.io"} {
+		command := fmt.Sprintf("docker login -u %s -p %s https://%s", "oauth2accesstoken", storage.GetInstance().GCRAuth.AccessToken, registry)
 		// Gross hack untill "github.com/moby/moby" can be fetched using go get
-		if err := sh.ShellCommand(fmt.Sprintf("docker login -u %s -p %s https://%s", "oauth2accesstoken", storage.GetInstance().GCRAuth.AccessToken, registry), "", false); err != nil {
+		if err := sh.ShellCommand(command, "", false); err != nil {
 			return err
 		}
 	}

--- a/commands/kubebuilder/commands.go
+++ b/commands/kubebuilder/commands.go
@@ -119,9 +119,8 @@ func BuildDockerImage(project string) error {
 		return err
 	}
 
-	// When resolve different config Types, we may also be rewriting
-	// content on disc, so this should ensure that content is always
-	// always as the user left it.
+	// When resolving different config types, we may also be rewriting
+	// content on disc, so this should ensure that content as the user left it.
 	switch config.Type {
 	case "node":
 		defer node.RestoreBackups()

--- a/commands/kubebuilder/kubebuilder.go
+++ b/commands/kubebuilder/kubebuilder.go
@@ -27,6 +27,9 @@ func AddCommands(cli *cli.Cli) {
 					} else {
 						color.Green("Successfully logged in")
 					}
+					if err := authenticateDocker(); err != nil {
+						color.Red("We have failed %v", err)
+					}
 				},
 			},
 			command.Command{

--- a/commands/kubebuilder/kubebuilder.go
+++ b/commands/kubebuilder/kubebuilder.go
@@ -34,7 +34,7 @@ func AddCommands(cli *cli.Cli) {
 				Help: "Builds a docker image based off a kepler definitions",
 				Func: func(args []string) {
 					if len(args) == 0 {
-						color.Red("Please tpye what projects you expect to build")
+						color.Red("Please type what projects you expect to build")
 						return
 					}
 					for _, project := range args {

--- a/commands/kubebuilder/kubebuilder.go
+++ b/commands/kubebuilder/kubebuilder.go
@@ -20,16 +20,17 @@ func AddCommands(cli *cli.Cli) {
 		SubCommands: []command.Command{
 			command.Command{
 				Name: "auth",
-				Help: "Authenticates you against all required services",
+				Help: "Authenticates you into GCP GCR",
 				Func: func(args []string) {
 					if err := Authenticate(); err != nil {
 						color.Red("%v", err)
-					} else {
-						color.Green("Successfully logged in")
+						return
 					}
 					if err := authenticateDocker(); err != nil {
-						color.Red("We have failed %v", err)
+						color.Red("Failed to login %v", err)
+						return
 					}
+					color.Green("Docker Successfully logged into GCR")
 				},
 			},
 			command.Command{

--- a/commands/kubebuilder/kubebuilder.go
+++ b/commands/kubebuilder/kubebuilder.go
@@ -6,6 +6,7 @@ import (
 	"github.com/AlexsJones/cli/cli"
 	"github.com/AlexsJones/cli/command"
 	"github.com/fatih/color"
+	gcr-cli "github.com/GoogleCloudPlatform/docker-credential-gcr/cli"
 )
 
 //AddCommands for the kubebuilder module
@@ -18,6 +19,13 @@ func AddCommands(cli *cli.Cli) {
 			fmt.Println("See help for working with kubebuilder")
 		},
 		SubCommands: []command.Command{
+			command.Command{
+				Name: "auth",
+				Help: "Authenticates you against all required services",
+				Func: func(args []string) {
+					loginCmd := gcr-cli.NewGCRLoginSubcommand()
+				},
+			},
 			command.Command{
 				Name: "deploy",
 				Help: "Deploy to a remote kubebuilder cluster",

--- a/commands/kubebuilder/kubebuilder.go
+++ b/commands/kubebuilder/kubebuilder.go
@@ -29,6 +29,23 @@ func AddCommands(cli *cli.Cli) {
 				},
 			},
 			command.Command{
+				Name: "build",
+				Help: "Builds a docker image based off a kepler definitions",
+				Func: func(args []string) {
+					if len(args) == 0 {
+						color.Red("Please tpye what projects you expect to build")
+						return
+					}
+					for _, project := range args {
+						if err := BuildDockerImage(project); err != nil {
+							color.Red("%v", err)
+							color.Yellow("If this is an auth issue, please make sure you have authenticated with gcloud")
+							return
+						}
+					}
+				},
+			},
+			command.Command{
 				Name: "deploy",
 				Help: "Deploy to a remote kubebuilder cluster",
 				Func: func(args []string) {

--- a/commands/kubebuilder/kubebuilder.go
+++ b/commands/kubebuilder/kubebuilder.go
@@ -1,12 +1,14 @@
 package kubebuilder
 
 import (
+	"context"
+	"flag"
 	"fmt"
 
 	"github.com/AlexsJones/cli/cli"
 	"github.com/AlexsJones/cli/command"
+	gcr "github.com/GoogleCloudPlatform/docker-credential-gcr/cli"
 	"github.com/fatih/color"
-	gcr-cli "github.com/GoogleCloudPlatform/docker-credential-gcr/cli"
 )
 
 //AddCommands for the kubebuilder module
@@ -23,7 +25,7 @@ func AddCommands(cli *cli.Cli) {
 				Name: "auth",
 				Help: "Authenticates you against all required services",
 				Func: func(args []string) {
-					loginCmd := gcr-cli.NewGCRLoginSubcommand()
+					gcr.NewGCRLoginSubcommand().Execute(context.Background(), &flag.FlagSet{})
 				},
 			},
 			command.Command{

--- a/commands/kubebuilder/kubebuilder.go
+++ b/commands/kubebuilder/kubebuilder.go
@@ -1,14 +1,16 @@
 package kubebuilder
 
 import (
-	"context"
-	"flag"
+	"archive/tar"
+	"bytes"
 	"fmt"
+	"io/ioutil"
+	"time"
 
 	"github.com/AlexsJones/cli/cli"
 	"github.com/AlexsJones/cli/command"
-	gcr "github.com/GoogleCloudPlatform/docker-credential-gcr/cli"
 	"github.com/fatih/color"
+	rawdocker "github.com/fsouza/go-dockerclient"
 )
 
 //AddCommands for the kubebuilder module
@@ -25,7 +27,48 @@ func AddCommands(cli *cli.Cli) {
 				Name: "auth",
 				Help: "Authenticates you against all required services",
 				Func: func(args []string) {
-					gcr.NewGCRLoginSubcommand().Execute(context.Background(), &flag.FlagSet{})
+					access, err := authenticateDocker()
+					if err != nil {
+						color.Red("Failed to login")
+						color.Red("Due to %v", err)
+						return
+					} else {
+						color.Green("We are logged in to GCR")
+					}
+					client, _ := rawdocker.NewClientFromEnv()
+					t := time.Now()
+					dockerfile, err := ioutil.ReadFile("Dockerfile")
+					if err != nil {
+						color.Red("%v", err)
+						return
+					}
+					dockerfile = append(dockerfile, []byte("\n")...)
+					inputbuf, outputbuf := bytes.NewBuffer(nil), bytes.NewBuffer(nil)
+					tr := tar.NewWriter(inputbuf)
+					tr.WriteHeader(&tar.Header{
+						Name:       "Dockerfile",
+						Size:       int64(len(dockerfile) + 1),
+						ModTime:    t,
+						AccessTime: t,
+						ChangeTime: t,
+					})
+					tr.Write(dockerfile)
+					tr.Close()
+					opts := rawdocker.BuildImageOptions{
+						Name:         "api-core",
+						InputStream:  inputbuf,
+						OutputStream: outputbuf,
+						Auth:         *access,
+						AuthConfigs: rawdocker.AuthConfigurations{
+							Configs: map[string]rawdocker.AuthConfiguration{
+								"https://us.gcr.io": *access,
+							},
+						},
+					}
+					if err := client.BuildImage(opts); err != nil {
+						color.Red("We gone fucked up")
+						color.Red("%v", err)
+					}
 				},
 			},
 			command.Command{

--- a/commands/kubebuilder/kubebuilder.go
+++ b/commands/kubebuilder/kubebuilder.go
@@ -1,13 +1,10 @@
 package kubebuilder
 
 import (
-	"context"
-	"flag"
 	"fmt"
 
 	"github.com/AlexsJones/cli/cli"
 	"github.com/AlexsJones/cli/command"
-	gcr "github.com/GoogleCloudPlatform/docker-credential-gcr/cli"
 	"github.com/fatih/color"
 )
 
@@ -25,7 +22,11 @@ func AddCommands(cli *cli.Cli) {
 				Name: "auth",
 				Help: "Authenticates you against all required services",
 				Func: func(args []string) {
-					gcr.NewGCRLoginSubcommand().Execute(context.Background(), &flag.FlagSet{})
+					if err := Authenticate(); err != nil {
+						color.Red("%v", err)
+					} else {
+						color.Green("Successfully logged in")
+					}
 				},
 			},
 			command.Command{

--- a/commands/node/commands.go
+++ b/commands/node/commands.go
@@ -240,7 +240,8 @@ func updatePackageContents(project string, local map[string]*PackageJSON) (*Pack
 	return projectPackage, nil
 }
 
-//RestoreBackups will itterate
+// RestoreBackups will itterate through all the node projects and reset
+// their package.json back to what they were before being modified.
 func RestoreBackups() error {
 	local, err := LocalNodeModules()
 	if err != nil {

--- a/commands/node/commands.go
+++ b/commands/node/commands.go
@@ -12,6 +12,7 @@ import (
 
 	sh "github.com/AlexsJones/kepler/commands/shell"
 	"github.com/AlexsJones/kepler/commands/submodules"
+	"github.com/MovieStoreGuy/resources/marshal"
 	"github.com/fatih/color"
 
 	git "gopkg.in/src-d/go-git.v4"
@@ -34,7 +35,7 @@ type PackageJSON struct {
 // WriteTo will write the current contents of the PackageJSON
 // into the given directory
 func (pack *PackageJSON) WriteTo(path string) error {
-	o, err := json.MarshalIndent(pack, "", "    ")
+	o, err := marshal.PureMarshalIndent(pack, "", "    ")
 	if err != nil {
 		return err
 	}

--- a/commands/node/commands.go
+++ b/commands/node/commands.go
@@ -241,7 +241,6 @@ func CreateMetaPackageJson() (*PackageJSON, error) {
 		Version:         "1.0.0",
 		Description:     "An auto generated package json",
 		Main:            "index.js",
-		Author:          os.Args[0],
 		Dependencies:    map[string]string{},
 		DevDependencies: map[string]string{},
 		Scripts: map[string]string{

--- a/commands/node/commands.go
+++ b/commands/node/commands.go
@@ -232,12 +232,13 @@ func LinkLocalPackages(project string, local map[string]*PackageJSON) (*PackageJ
 	}
 	for name := range projectPackage.DevDependencies {
 		if _, exist := local[name]; exist {
-			projectPackage.Dependencies[name] = fmt.Sprintf("file:../%s", name)
+			projectPackage.DevDependencies[name] = fmt.Sprintf("file:../%s", name)
 		}
 	}
 	return projectPackage, nil
 }
 
+//RestoreBackups will itterate
 func RestoreBackups() error {
 	local, err := LocalNodeModules()
 	if err != nil {

--- a/commands/node/commands.go
+++ b/commands/node/commands.go
@@ -123,10 +123,10 @@ func LocalNodeModules() (map[string]*PackageJSON, error) {
 	return Projects, nil
 }
 
-// ResolveLocalDependancies will explore (via some graph expansion)
+// Resolve will explore (via some graph expansion)
 // once it is completed, it will return the list of the required
 // pacakages otherwise, return an informative error
-func ResolveLocalDependancies(project string) ([]string, error) {
+func Resolve(project string) ([]string, error) {
 	LocalPackages, err := LocalNodeModules()
 	if err != nil {
 		return []string{}, err

--- a/commands/node/commands.go
+++ b/commands/node/commands.go
@@ -112,9 +112,9 @@ func LocalNodeModules() (map[string]*PackageJSON, error) {
 				return
 			}
 			var p PackageJSON
-			json.Unmarshal(b, &p)
 			if err := json.Unmarshal(b, &p); err != nil {
 				log.Println(err.Error())
+				return
 			}
 			Projects[sub.Config().Name] = &p
 		}

--- a/commands/node/commands.go
+++ b/commands/node/commands.go
@@ -191,6 +191,9 @@ func LinkLocalDeps() error {
 		}
 		// Write new package json to disk
 		filepath = path.Join(dir, "package.json")
+		if err := os.Remove(filepath); err != nil {
+			return err
+		}
 		o, err := json.MarshalIndent(pack, "", "    ")
 		if err != nil {
 			return err

--- a/commands/node/commands.go
+++ b/commands/node/commands.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/AlexsJones/kepler/commands/submodules"
 	"github.com/MovieStoreGuy/resources/files"
+	"github.com/MovieStoreGuy/resources/marshal"
 	"github.com/fatih/color"
 
 	git "gopkg.in/src-d/go-git.v4"
@@ -194,7 +195,7 @@ func LinkLocalDeps() error {
 		if err := os.Remove(filepath); err != nil {
 			return err
 		}
-		o, err := json.MarshalIndent(pack, "", "    ")
+		o, err := marshal.PureMarshalIndent(pack, "", "    ")
 		if err != nil {
 			return err
 		}

--- a/commands/node/commands.go
+++ b/commands/node/commands.go
@@ -10,6 +10,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	sh "github.com/AlexsJones/kepler/commands/shell"
 	"github.com/AlexsJones/kepler/commands/submodules"
 	"github.com/MovieStoreGuy/resources/files"
 	"github.com/MovieStoreGuy/resources/marshal"
@@ -223,14 +224,9 @@ func RestoreBackups() error {
 	}
 	for name := range local {
 		filepath := path.Join(name, "package.json.bak")
+		os.Remove(filepath)
 		if _, err = os.Stat(filepath); !os.IsNotExist(err) {
-			if err = files.Copy(filepath, path.Join(name, "package.json")); err != nil {
-				return err
-			}
-			// Need to remove the packup file
-			if err = os.Remove(filepath); err != nil {
-				return err
-			}
+			sh.ShellCommand("git checkout HEAD -- package.json", name, false)
 		}
 	}
 	return nil

--- a/commands/node/commands.go
+++ b/commands/node/commands.go
@@ -92,7 +92,7 @@ func fixLinks(subPath string, filename string, prefix string, target string, sho
 	return ioutil.WriteFile(filepath, o, 0644)
 }
 
-// NewInformation creates a struct containing information about the meta repo
+// LocalNodeModules creates a struct containing information about the meta repo
 func LocalNodeModules() (map[string]*PackageJSON, error) {
 	Projects := make(map[string]*PackageJSON)
 	submodules.LoopSubmodules(func(sub *git.Submodule) {
@@ -158,4 +158,26 @@ func ResolveLocalDependancies(project string) ([]string, error) {
 		deps = append(deps, dep)
 	}
 	return deps, nil
+}
+
+func LinkLocalDeps() error {
+	local, err := LocalNodeModules()
+	if err != nil {
+		return err
+	}
+	for _, pack := range local {
+		// Need to create a backup file
+		for name := range pack.Dependencies {
+			if _, exist := local[name]; exist {
+				pack.Dependencies[name] = fmt.Sprintf("file:%s", name)
+			}
+		}
+		for name := range pack.DevDependencies {
+			if _, exist := local[name]; exist {
+				pack.DevDependencies[name] = fmt.Sprintf("file:%s", name)
+			}
+		}
+		// Write new package json to disk
+	}
+	return nil
 }

--- a/commands/node/commands.go
+++ b/commands/node/commands.go
@@ -6,6 +6,7 @@ import (
 	"io/ioutil"
 	"os"
 	"path"
+	"path/filepath"
 	"strings"
 
 	"github.com/AlexsJones/kepler/commands/submodules"
@@ -221,4 +222,31 @@ func RestoreBackups() error {
 		}
 	}
 	return nil
+}
+
+func CreateMetaPackageJson() (*PackageJSON, error) {
+	metaPackage := &PackageJSON{
+		Version:         "1.0.0",
+		Description:     "An auto generated package json",
+		Main:            "index.js",
+		Author:          os.Args[0],
+		Dependencies:    map[string]string{},
+		DevDependencies: map[string]string{},
+		Scripts: map[string]string{
+			"test": "true",
+		},
+	}
+	if name, err := os.Getwd(); err != nil {
+		return nil, err
+	} else {
+		metaPackage.Name = filepath.Base(name)
+	}
+	modules, err := LocalNodeModules()
+	if err != nil {
+		return nil, err
+	}
+	for name := range modules {
+		metaPackage.Dependencies[name] = fmt.Sprintf("file:%s", name)
+	}
+	return metaPackage, nil
 }

--- a/commands/node/commands.go
+++ b/commands/node/commands.go
@@ -204,7 +204,7 @@ func LinkLocalDeps() error {
 	}
 	for dir := range local {
 		color.Blue("Updating %s links", dir)
-		pack, err := LinkLocalPackages(dir, local)
+		pack, err := updatePackageContents(dir, local)
 		if err != nil {
 			return err
 		}
@@ -220,9 +220,9 @@ func LinkLocalDeps() error {
 	return nil
 }
 
-// LinkLocalPackages will update a project Dependencies if they can
+// UpdatePackageContents will update a project Dependencies if they can
 // be found locally and update their resource to be a file link
-func LinkLocalPackages(project string, local map[string]*PackageJSON) (*PackageJSON, error) {
+func updatePackageContents(project string, local map[string]*PackageJSON) (*PackageJSON, error) {
 	if _, exist := local[project]; !exist {
 		return nil, fmt.Errorf("Project can not be found locally")
 	}

--- a/commands/node/commands.go
+++ b/commands/node/commands.go
@@ -141,8 +141,9 @@ func LocalNodeModules() (map[string]*PackageJSON, error) {
 	return Projects, nil
 }
 
-// Resolve will explore (via some graph expansion)
-// once it is completed, it will return the list of the required
+// Resolve will explore search through the given package json of project
+// and all the required projects found locally.
+// Once it is completed, it will return the list of the required
 // pacakages otherwise, return an informative error
 func Resolve(project string) ([]string, error) {
 	LocalPackages, err := LocalNodeModules()
@@ -244,10 +245,11 @@ func RestoreBackups() error {
 		return err
 	}
 	for name := range local {
-		filepath := path.Join(name, "package.json.bak")
-		os.Remove(filepath)
-		if _, err = os.Stat(filepath); !os.IsNotExist(err) {
-			sh.ShellCommand("git checkout HEAD -- package.json", name, false)
+		if _, err = os.Stat("package.json"); !os.IsNotExist(err) {
+			err := sh.ShellCommand("git checkout HEAD -- package.json", name, false)
+			if err != nil {
+				return err
+			}
 		}
 	}
 	return nil

--- a/commands/node/node.go
+++ b/commands/node/node.go
@@ -82,7 +82,7 @@ func AddCommands(cli *cli.Cli) {
 						return
 					}
 					if len(i) == 0 {
-						color.Red("There appears to be no happiness in the world")
+						color.Red("No submodules found")
 						return
 					}
 					for name := range i {

--- a/commands/node/node.go
+++ b/commands/node/node.go
@@ -92,24 +92,6 @@ func AddCommands(cli *cli.Cli) {
 				},
 			},
 			command.Command{
-				Name: "link",
-				Help: "Force all local node projects to use local projects",
-				Func: func(args []string) {
-					if err := LinkLocalDeps(); err != nil {
-						color.Red("Appears an error occured: %s", err.Error())
-					}
-				},
-			},
-			command.Command{
-				Name: "restore",
-				Help: "Restores all backup files to the original",
-				Func: func(args []string) {
-					if err := RestoreBackups(); err != nil {
-						color.Red("Something bad has occured: %s", err.Error())
-					}
-				},
-			},
-			command.Command{
 				Name: "install",
 				Help: "Installs all the required vendor code",
 				Func: func(args []string) {
@@ -127,7 +109,7 @@ func AddCommands(cli *cli.Cli) {
 				},
 			},
 			command.Command{
-				Name: "package",
+				Name: "init",
 				Help: "Create the package json for a meta repo",
 				Func: func(args []string) {
 					pack, err := CreateMetaPackageJson()

--- a/commands/node/node.go
+++ b/commands/node/node.go
@@ -140,12 +140,10 @@ type PackageJSON struct {
 	Version         string            `json:"version"`
 	Description     string            `json:"description"`
 	Main            string            `json:"main"`
-	Author          string            `json:"author,omitempty"`
 	Bugs            map[string]string `json:"bugs,omitempty"`
 	Scripts         map[string]string `json:"scripts,omitempty"`
 	Dependencies    map[string]string `json:"dependencies,omitempty"`
 	DevDependencies map[string]string `json:"devDependencies,omitempty"`
-	Repository      map[string]string `json:"repository,omitempty"`
 	Private         bool              `json:"private,omitempty"`
 	License         string            `json:"license,omitempty"`
 }

--- a/commands/node/node.go
+++ b/commands/node/node.go
@@ -94,6 +94,10 @@ func AddCommands(cli *cli.Cli) {
 				Name: "install",
 				Help: "Installs all the required vendor code",
 				Func: func(args []string) {
+					if _, err := os.Stat("package.json"); os.IsNotExist(err) {
+						color.Red("No package.json found in current directory")
+						return
+					}
 					defer func() {
 						color.Yellow("Restoring backups")
 						RestoreBackups()

--- a/commands/node/node.go
+++ b/commands/node/node.go
@@ -137,6 +137,7 @@ func AddCommands(cli *cli.Cli) {
 					}
 					color.Yellow("Attempting to install")
 					sh.ShellCommand("npm i", "", true)
+					color.Yellow("Restoring backups")
 					if err := RestoreBackups(); err != nil {
 						color.Red("Failed to restore backups, %s", err.Error())
 					}

--- a/commands/node/node.go
+++ b/commands/node/node.go
@@ -3,7 +3,6 @@
 package node
 
 import (
-	"encoding/json"
 	"fmt"
 	"io/ioutil"
 
@@ -11,6 +10,7 @@ import (
 	"github.com/AlexsJones/cli/command"
 	sh "github.com/AlexsJones/kepler/commands/shell"
 	"github.com/AlexsJones/kepler/commands/submodules"
+	"github.com/MovieStoreGuy/resources/marshal"
 	"github.com/fatih/color"
 	"gopkg.in/src-d/go-git.v4"
 )
@@ -25,23 +25,6 @@ func AddCommands(cli *cli.Cli) {
 			fmt.Println("See help for working with npm")
 		},
 		SubCommands: []command.Command{
-			command.Command{
-				Name: "file",
-				Help: "relink an npm package locally<prefix> <string>",
-				Func: func(args []string) {
-					if len(args) < 2 {
-						fmt.Println("Please give a target package string to try to convert to a file link <prefix> <string> e.g. file ../../ googleremotes.git")
-						return
-					}
-					submodules.LoopSubmodules(func(sub *git.Submodule) {
-						if err := fixLinks(sub.Config().Path, "package.json", args[0], args[1], false); err != nil {
-							fmt.Println(err.Error())
-						} else {
-							fmt.Printf("- Link fixed: %s\n", sub.Config().Path)
-						}
-					})
-				},
-			},
 			command.Command{
 				Name: "remove",
 				Help: "remove a dep from package.json <string>",
@@ -154,7 +137,7 @@ func AddCommands(cli *cli.Cli) {
 					}
 					// Write new package json to disk
 					filepath := "package.json"
-					o, err := json.MarshalIndent(pack, "", "    ")
+					o, err := marshal.PureMarshalIndent(pack, "", "    ")
 					if err != nil {
 						color.Red("An error occured, %s", err.Error())
 						return
@@ -176,9 +159,11 @@ type PackageJSON struct {
 	Description     string            `json:"description"`
 	Main            string            `json:"main"`
 	Author          string            `json:"author,omitempty"`
+	Bugs            map[string]string `json:"bugs,omitempty"`
 	Scripts         map[string]string `json:"scripts,omitempty"`
 	Dependencies    map[string]string `json:"dependencies,omitempty"`
 	DevDependencies map[string]string `json:"devDependencies,omitempty"`
+	Repository      map[string]string `json:"repository,omitempty"`
 	Private         bool              `json:"private,omitempty"`
 	License         string            `json:"license,omitempty"`
 }

--- a/commands/node/node.go
+++ b/commands/node/node.go
@@ -105,6 +105,15 @@ func AddCommands(cli *cli.Cli) {
 					}
 				},
 			},
+			command.Command{
+				Name: "link",
+				Help: "Force all local node projects to use local projects",
+				Func: func(args []string) {
+					if err := LinkLocalDeps(); err != nil {
+						color.Red("Appears an error occured: %s", err.Error())
+					}
+				},
+			},
 		},
 	})
 }

--- a/commands/node/node.go
+++ b/commands/node/node.go
@@ -135,12 +135,12 @@ func AddCommands(cli *cli.Cli) {
 						color.Red("Failed to link: %s", err.Error())
 						return
 					}
+					defer func() {
+						color.Yellow("Restoring backups")
+						RestoreBackups()
+					}()
 					color.Yellow("Attempting to install")
 					sh.ShellCommand("npm i", "", true)
-					color.Yellow("Restoring backups")
-					if err := RestoreBackups(); err != nil {
-						color.Red("Failed to restore backups, %s", err.Error())
-					}
 				},
 			},
 			command.Command{

--- a/commands/node/node.go
+++ b/commands/node/node.go
@@ -5,6 +5,7 @@ package node
 import (
 	"fmt"
 	"io/ioutil"
+	"os"
 
 	"github.com/AlexsJones/cli/cli"
 	"github.com/AlexsJones/cli/command"
@@ -119,6 +120,9 @@ func AddCommands(cli *cli.Cli) {
 					}
 					// Write new package json to disk
 					filepath := "package.json"
+					// Have to ensure that remove the old package.json
+					// Otherwise there could be issues.
+					os.Remove(filepath)
 					o, err := marshal.PureMarshalIndent(pack, "", "    ")
 					if err != nil {
 						color.Red("An error occured, %s", err.Error())

--- a/commands/node/node.go
+++ b/commands/node/node.go
@@ -114,6 +114,15 @@ func AddCommands(cli *cli.Cli) {
 					}
 				},
 			},
+			command.Command{
+				Name: "restore",
+				Help: "Restores all backup files to the original",
+				Func: func(args []string) {
+					if err := RestoreBackups(); err != nil {
+						color.Red("Something bad has occured: %s", err.Error())
+					}
+				},
+			},
 		},
 	})
 }

--- a/commands/node/node.go
+++ b/commands/node/node.go
@@ -78,7 +78,7 @@ func AddCommands(cli *cli.Cli) {
 				Help: "Shows all the dependancies found locally",
 				Func: func(args []string) {
 					for _, project := range args {
-						deps, err := ResolveLocalDependancies(project)
+						deps, err := Resolve(project)
 						if err != nil {
 							color.Red("The hell?!: %s", err.Error())
 						} else {

--- a/commands/node/node.go
+++ b/commands/node/node.go
@@ -5,6 +5,7 @@ package node
 import (
 	"fmt"
 	"os"
+	"strings"
 
 	"github.com/AlexsJones/cli/cli"
 	"github.com/AlexsJones/cli/command"
@@ -108,7 +109,7 @@ func AddCommands(cli *cli.Cli) {
 						return
 					}
 					color.Yellow("Attempting to install")
-					sh.ShellCommand("npm i", "", true)
+					sh.ShellCommand(fmt.Sprintf("npm i %s", strings.Join(args, " ")), "", true)
 				},
 			},
 			command.Command{

--- a/commands/node/node.go
+++ b/commands/node/node.go
@@ -128,7 +128,9 @@ func AddCommands(cli *cli.Cli) {
 					if err = pack.WriteTo(filepath); err != nil {
 						color.Red("Failed to write linked %s", filepath)
 						color.Red("Due to %v", err)
+						return
 					}
+					color.Green("Successfully created new package.json")
 				},
 			},
 		},

--- a/commands/node/node.go
+++ b/commands/node/node.go
@@ -175,8 +175,10 @@ type PackageJSON struct {
 	Version         string            `json:"version"`
 	Description     string            `json:"description"`
 	Main            string            `json:"main"`
-	Author          string            `json:"author"`
-	Scripts         map[string]string `json:"scripts"`
-	Dependencies    map[string]string `json:"dependencies"`
-	DevDependencies map[string]string `json:"devDependencies"`
+	Author          string            `json:"author,omitempty"`
+	Scripts         map[string]string `json:"scripts,omitempty"`
+	Dependencies    map[string]string `json:"dependencies,omitempty"`
+	DevDependencies map[string]string `json:"devDependencies,omitempty"`
+	Private         bool              `json:"private,omitempty"`
+	License         string            `json:"license,omitempty"`
 }

--- a/commands/shell/shell.go
+++ b/commands/shell/shell.go
@@ -11,7 +11,7 @@ import (
 
 //ShellCommand lets you perform a shell command in bash
 //It also captures stderr and stdout into Kepler
-func ShellCommand(command string, path string, validated bool) {
+func ShellCommand(command string, path string, validated bool) error {
 	cmd := exec.Command("bash", "-c", command)
 	if path != "" {
 		cmd.Dir = path
@@ -33,13 +33,14 @@ func ShellCommand(command string, path string, validated bool) {
 		}
 	}()
 	if err := cmd.Start(); err != nil {
-		fmt.Println(err.Error())
+		return err
 	}
 	if err := cmd.Wait(); err != nil {
-		fmt.Println(err.Error())
+		return err
 	} else {
 		if validated {
 			color.Green("Successful")
 		}
 	}
+	return nil
 }

--- a/commands/shell/shell.go
+++ b/commands/shell/shell.go
@@ -38,6 +38,8 @@ func ShellCommand(command string, path string, validated bool) {
 	if err := cmd.Wait(); err != nil {
 		fmt.Println(err.Error())
 	} else {
-		color.Green("Successful")
+		if validated {
+			color.Green("Successful")
+		}
 	}
 }

--- a/commands/storage/storage.go
+++ b/commands/storage/storage.go
@@ -14,6 +14,7 @@ import (
 	"github.com/AlexsJones/cli/command"
 	"github.com/fatih/color"
 	homedir "github.com/mitchellh/go-homedir"
+	"golang.org/x/oauth2"
 )
 
 //AddCommands for this module
@@ -49,8 +50,9 @@ const store = ".kepler"
 
 //Storage structure
 type Storage struct {
-	Github      *Github      `json:"github"`
-	Kubebuilder *Kubebuilder `json:"kubebuilder"`
+	Github      *Github       `json:"github"`
+	Kubebuilder *Kubebuilder  `json:"kubebuilder"`
+	GCRAuth     *oauth2.Token `json:"GCRAuth"`
 }
 
 //Kubebuilder specific sub structure

--- a/commands/storage/storage.go
+++ b/commands/storage/storage.go
@@ -102,16 +102,20 @@ func GetInstance() *Storage {
 			fmt.Println(err)
 			panic(err)
 		}
-		if doesExist != true {
+		switch {
+		case doesExist:
+			i, err := Load()
+			if err == nil {
+				instance = i
+				break
+			}
+			color.Red("Unable to load stored data due to: %v", err)
+			fallthrough
+		default:
+			color.Yellow("Creating storage defaults")
 			instance = &Storage{}
 			instance.Github = &Github{TeamID: 0}
 			instance.Kubebuilder = &Kubebuilder{}
-		} else {
-			i, err := Load()
-			if err != nil {
-				panic(err)
-			}
-			instance = i
 		}
 	})
 	return instance
@@ -182,9 +186,8 @@ func Load() (*Storage, error) {
 		return nil, err
 	}
 	var s Storage
-	json.Unmarshal(b, &s)
-
-	return &s, nil
+	err = json.Unmarshal(b, &s)
+	return &s, err
 }
 
 //ShowStorage in kepler

--- a/main.go
+++ b/main.go
@@ -44,7 +44,10 @@ func main() {
 	docker.AddCommands(cli)
 	//-------------------------------------------
 	//Additional commands
-	github.Login()
+	// Only automatically login if there is AccessToken set
+	if store := storage.GetInstance(); store.Github.AccessToken != "" {
+		github.Login()
+	}
 	//-------------------------------------------
 	cli.Run()
 }

--- a/main.go
+++ b/main.go
@@ -8,6 +8,7 @@ import (
 	"os"
 
 	"github.com/AlexsJones/cli/cli"
+	"github.com/AlexsJones/kepler/commands/docker"
 	"github.com/AlexsJones/kepler/commands/github"
 	"github.com/AlexsJones/kepler/commands/kubebuilder"
 	"github.com/AlexsJones/kepler/commands/node"
@@ -40,6 +41,7 @@ func main() {
 	submodules.AddCommands(cli)
 	storage.AddCommands(cli)
 	palette.AddCommands(cli)
+	docker.AddCommands(cli)
 	//-------------------------------------------
 	//Additional commands
 	github.Login()


### PR DESCRIPTION
This PR adds the following to Kepler:
- The starting stages for Auth for `kubebuilder` and `Google Container Registry`
  - Requires further work with a working docker api
- Introduces the ability to build docker files in `standalone` and within a meta repo
- Adds tests to `docker` to ensure behaviour is as expected
- Correctly marshalling data from package.json files
- Ensure that the shell command is blocking
- Only automatically login to github if there is a token set